### PR TITLE
Removing unnecessary endsWith helper

### DIFF
--- a/library/helpers/BarionHelper.php
+++ b/library/helpers/BarionHelper.php
@@ -34,8 +34,3 @@ function jget($json, $propertyName)
 {
     return isset($json[$propertyName]) ? $json[$propertyName] : null;
 }
-
-function endsWith($haystack, $needle)
-{
-    return $needle === "" || (($temp = strlen($haystack) - strlen($needle)) >= 0 && strpos($haystack, $needle, $temp) !== FALSE);
-}


### PR DESCRIPTION
The helper `endsWith` is not in use, and it's already defined by numerous packages, leading to a `Cannot redeclare endsWith` fatal error.