### PR TITLE
Setting TLSv1.2 option for CURL if php version is below 5.6

### DIFF
--- a/library/BarionClient.php
+++ b/library/BarionClient.php
@@ -210,6 +210,10 @@ class BarionClient
         curl_setopt($ch, CURLOPT_POSTFIELDS, $postData);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_HTTPHEADER, array("Content-Type: application/json", "User-Agent: $userAgent"));
+        
+        if(substr(phpversion(), 0, 3) < 5.6) {
+            curl_setopt($ch, CURLOPT_SSLVERSION, 6);
+        }
 
         if ($this->UseBundledRootCertificates) {
             curl_setopt($ch, CURLOPT_CAINFO, join(DIRECTORY_SEPARATOR, array(dirname(__FILE__), 'ssl', 'cacert.pem')));
@@ -259,6 +263,10 @@ class BarionClient
         curl_setopt($ch, CURLOPT_URL, $fullUrl);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_HTTPHEADER, array("User-Agent: $userAgent"));
+        
+        if(substr(phpversion(), 0, 3) < 5.6) {
+            curl_setopt($ch, CURLOPT_SSLVERSION, 6);
+        }
 
         if ($this->UseBundledRootCertificates) {
             curl_setopt($ch, CURLOPT_CAINFO, join(DIRECTORY_SEPARATOR, array(dirname(__FILE__), 'ssl', 'cacert.pem')));


### PR DESCRIPTION
It's a fix for setting the correct version of TLS for CURL request below PHP5.6.
In other case PHP CURL extension will use the default TLS of the version of PHP.
Which is below 1.0.