### PR TITLE
Fallback to empty string if HTTP user agent does not exist in the context of the API call

### DIFF
--- a/library/BarionClient.php
+++ b/library/BarionClient.php
@@ -411,7 +411,10 @@ class BarionClient
         $ch = curl_init();
         $posKey = $this->POSKey;
         
-        $userAgent = $_SERVER['HTTP_USER_AGENT'];
+        $userAgent = "";
+        if (isset($_SERVER['HTTP_USER_AGENT'])) {
+            $userAgent = $_SERVER['HTTP_USER_AGENT'] ?? "";
+        }
         if ($userAgent == "") {
             $cver = (array)curl_version();
             $userAgent = "curl/" . $cver["version"] . " " .$cver["ssl_version"];
@@ -447,7 +450,10 @@ class BarionClient
         $getData = http_build_query($data);
         $fullUrl = $url . '?' . $getData;
         
-        $userAgent = $_SERVER['HTTP_USER_AGENT'];
+        $userAgent = "";
+        if (isset($_SERVER['HTTP_USER_AGENT'])) {
+            $userAgent = $_SERVER['HTTP_USER_AGENT'] ?? "";
+        }
         if ($userAgent == "") {
             $cver = (array)curl_version();
             $userAgent = "curl/" . $cver["version"] . " " .$cver["ssl_version"];
@@ -492,4 +498,5 @@ class BarionClient
 
         return $output;
     }
+
 }


### PR DESCRIPTION
$_SERVER['HTTP_USER_AGENT'] does not always exist (e.g if API is called from a command line / curl script). Some PHP8+ versions will throw an exception when accessing an array with a non-existing key. The array key should be explicitly checked and null values should fall back to an empty string.